### PR TITLE
Изменил размеры контейнера

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -338,7 +338,7 @@
 
 /* Container */
 .container {
-	width: 1165px;
+	width: 1200px;
 	margin: 0 auto;
 	padding: 0 0px;
 	padding-left: 20px;
@@ -924,7 +924,7 @@
 /*-- Filters --*/
 
 .filters {
-	width: 265px;
+	width: 260px;
 	margin-left: 0px;
 }
 
@@ -1113,7 +1113,8 @@
 
 /*-- Catalog --*/
 .catalog{
-	margin-left: 145px;
+	margin-left: 167px;
+	width: 760px;
 }
 
 .filter-class {
@@ -1158,7 +1159,6 @@
 
 .filter-class-pagination {
 	display: flex;
-	flex-wrap: wrap;
 	padding: 0;
 	margin: 0;
 	margin-top: 25px;
@@ -1170,7 +1170,7 @@
 }
 
 .filter-class-pagination li:not(:last-child){
-	margin-right: 10px;
+	margin-right: 11px;
 }
 
 .filter-class-pagination li:hover{

--- a/css/style.css
+++ b/css/style.css
@@ -212,6 +212,7 @@
 	height: 50px;
 	padding-left: 85px;
 	padding-right: 85px;
+	margin-left: 0px;
 	background-color: var(--basik-gray);
 	border: none;
 	color: var(--basik-black);
@@ -337,10 +338,11 @@
 
 /* Container */
 .container {
-	width: 1184px;
+	width: 1165px;
 	margin: 0 auto;
-	padding: 0 10px;
-	padding-left: 33px;
+	padding: 0 0px;
+	padding-left: 20px;
+	padding-right: 20px;
 }
 
 
@@ -606,8 +608,10 @@
 	margin: 0;
 	padding: 0;
 	margin-top: 55px;
+	padding-left: 5px;
 	position: relative;
 	display: block;
+	
 	text-align: center;
 }
 
@@ -921,14 +925,14 @@
 
 .filters {
 	width: 265px;
-	margin-left: 16px;
+	margin-left: 0px;
 }
 
 .filter fieldset {
 	padding: 0;
 	margin: 0;
 	border: 0;
-	margin-bottom: 35px;
+	margin-bottom: 23px;
 }
 
 .filter-option {
@@ -963,8 +967,8 @@
 .range-filter {
 	width: 260px;
 	margin-top: 50px;
-	margin-left: 5px;
-	margin-bottom: 20px;
+	margin-left: 0px;
+	margin-bottom: 30px;
 }
 
 .filter-item legend {
@@ -972,7 +976,7 @@
 	line-height: 24px;
 	text-transform: uppercase;
 	font-weight: 700;
-	padding-left: 5px;
+	padding-left: 0px;
 }
 
 .range-controls {
@@ -1070,6 +1074,8 @@
 }
 
 /* --Filter-checkbox --*/
+
+
 .filter-input-checkbox + label::before {
 	content: "";
 	position: absolute;
@@ -1107,7 +1113,7 @@
 
 /*-- Catalog --*/
 .catalog{
-	margin-left: 160px;
+	margin-left: 145px;
 }
 
 .filter-class {
@@ -1160,8 +1166,11 @@
 }
 
 .filter-class-pagination li{
-	margin-right: 7px;
 	opacity: 0.3;
+}
+
+.filter-class-pagination li:not(:last-child){
+	margin-right: 10px;
 }
 
 .filter-class-pagination li:hover{


### PR DESCRIPTION
Не могу сделать размер контейнера меньше 165рх. Паддинги контейнера поменял на 20рх слева и справа. Если ставлю размера контейнера меньше 165рхю В странице каталога сразу картинки выстраиваются в одну колонку вместо двух. И также над картинками сайтов справа есть два треугольника-пагинации. Второй треугольник при уменьшении размера контейнера переносится на вторую строчку